### PR TITLE
Implement hof-build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true
+
+rules:
+  no-console: 0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # hof-build
 Performs build workflow for hof apps in prod and development
+
+## Usage
+
+Run a build by running `hof-build` from the command line in your project directory.
+
+```
+hof build [task]
+```
+
+If no task is specified then all tasks will run.
+
+It is recommended to alias `hof-build` to an npm script in your package.json.
+
+## Tasks
+
+* `browserify` - compiles client-side js with browserify
+* `sass` - compiles sass
+* `images` - copies images from ./assets/images directory to ./public/images
+* `translate` - compiles translation files
+
+## Watch
+
+You can additionally run a `watch` task to start a server instance, which will automatically restart based on changes to files. This will also re-perform the tasks above when relevant files change.
+
+## Configuration
+
+The default settings will match those for an app generated using [`hof-generator`](https://npmjs.com/hof-generator). To override any of the configuration settings you can define a path to a local config file, which will be merged with [the default configuration](./config/defaults.js)
+
+```
+hof-build --config /path/to/my/config.js
+```
+
+### Configuration options
+
+Each task has a common configuration format with the following options:
+
+* `src` - defines the input file or files for the build task
+* `out` - defines the output location of the built code where relevant
+* `match` - defines the pattern for files to watch to trigger a rebuilt of this task
+* `restart` - defines if this task should result in a server restart
+
+Additionally the server instance created by `watch` can be configured by setting `server` config. Available options are:
+
+* `cmd` - defines the command used to start the server
+* `extensions` - defines the file extensions which will be watched to trigger a restart

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The default settings will match those for an app generated using [`hof-generator
 hof-build --config /path/to/my/config.js
 ```
 
+Any task can be disabled by setting its configuration to `false` (or any falsy value).
+
+```js
+module.exports = {
+  browserify: false
+};
+```
+
 ### Configuration options
 
 Each task has a common configuration format with the following options:

--- a/bin/hof-build
+++ b/bin/hof-build
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
+'use strict';
 const options = require('minimist')(process.argv.slice(2));
-
 require('../')(options);

--- a/bin/hof-build
+++ b/bin/hof-build
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const options = require('minimist')(process.argv.slice(2));
+
+require('../')(options);

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  browserify: {
+    src: 'assets/js/index.js',
+    out: 'public/js/bundle.js',
+    match: 'assets/js/**/*.js',
+    restart: false
+  },
+  sass: {
+    src: 'assets/scss/app.scss',
+    out: 'public/css/app.css',
+    match: 'assets/scss/**/*.scss',
+    restart: false
+  },
+  translate: {
+    src: 'apps/**/translations/src',
+    match: 'apps/**/translations/src/**/*.json'
+  },
+  images: {
+    src: 'assets/images',
+    out: 'public',
+    match: 'assets/images/**/*',
+    restart: false
+  },
+  server: {
+    cmd: 'npm start',
+    extensions: ['.js', '.json', '.html']
+  },
+  watch: {
+    ignore: [
+      '*.log',
+      'public'
+    ]
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = options => {
+
+  const merge = require('lodash.merge');
+
+  const config = require('./config/defaults');
+
+  if (options.config) {
+    merge(config, require(options.config));
+  }
+
+  merge(config, {
+    watchNodeModules: options['watch-node-modules']
+  });
+
+  const task = options._[0] || 'build';
+
+  let runner;
+
+  try {
+    runner = require(`./tasks/${task}`);
+  } catch (e) {
+    throw new Error(`Unknown task: ${task}`);
+  }
+
+  return runner(config);
+
+};

--- a/index.js
+++ b/index.js
@@ -1,29 +1,30 @@
 'use strict';
 
+const merge = require('lodash.merge');
+const config = require('./config/defaults');
+
 module.exports = options => {
 
-  const merge = require('lodash.merge');
+  const settings = {};
 
-  const config = require('./config/defaults');
+  merge(settings, config);
 
   if (options.config) {
-    merge(config, require(options.config));
+    merge(settings, require(options.config));
   }
 
-  merge(config, {
-    watchNodeModules: options['watch-node-modules']
-  });
+  if (options['watch-node-modules']) {
+    settings.watchNodeModules = true;
+  }
 
   const task = options._[0] || 'build';
 
-  let runner;
-
   try {
-    runner = require(`./tasks/${task}`);
+    require.resolve(`./tasks/${task}`);
   } catch (e) {
     throw new Error(`Unknown task: ${task}`);
   }
 
-  return runner(config);
+  return require(`./tasks/${task}`)(settings);
 
 };

--- a/lib/mkdir.js
+++ b/lib/mkdir.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+module.exports = (file) => {
+  return new Promise((resolve, reject) => {
+    const dir = path.dirname(file);
+    mkdirp(dir, err => {
+      return err ? reject(err) : resolve();
+    });
+  });
+};

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = (tasks, config) => {
+  return tasks.reduce((promise, task) => {
+    const name = task.task || 'unknown';
+    return promise
+      .then(() => {
+        console.log(`Executing task: ${name}`);
+        return task(config);
+      })
+      .then(() => {
+        console.log(`Completed task: ${name}`);
+      });
+  }, Promise.resolve())
+  .then(() => {
+    console.log();
+  });
+};

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const cp = require('child_process');
+
+module.exports = (cmd, args) => {
+  return new Promise((resolve, reject) => {
+    const child = cp.spawn(cmd, args, {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      shell: true
+    });
+    child.on('error', reject);
+    child.on('exit', code => {
+      return code === 0 ? resolve() : reject(new Error(`${cmd} exited with a non-zero code: ${code}`));
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "hof-build": "./bin/hof-build"
   },
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint . && eslint bin/hof-build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "hof-build",
+  "version": "1.0.0",
+  "description": "Performs build workflow for hof apps in prod and development",
+  "main": "index.js",
+  "bin": {
+    "hof-build": "./bin/hof-build"
+  },
+  "scripts": {
+    "test": "eslint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UKHomeOfficeForms/hof-build.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/UKHomeOfficeForms/hof-build/issues"
+  },
+  "homepage": "https://github.com/UKHomeOfficeForms/hof-build#readme",
+  "dependencies": {
+    "browserify": "^14.1.0",
+    "chalk": "^1.1.3",
+    "chokidar": "^1.6.1",
+    "cp": "^0.2.0",
+    "hof-transpiler": "^1.0.0",
+    "lodash.merge": "^4.6.0",
+    "lodash.throttle": "^4.1.1",
+    "lodash.uniq": "^4.5.0",
+    "minimatch": "^3.0.3",
+    "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1",
+    "npm-sass": "^2.0.0",
+    "witch": "^1.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.17.1",
+    "eslint-config-homeoffice": "^2.1.2"
+  }
+}

--- a/tasks/browserify/index.js
+++ b/tasks/browserify/index.js
@@ -7,6 +7,11 @@ const path = require('path');
 const mkdir = require('../../lib/mkdir');
 
 module.exports = config => {
+
+  if (!config.browserify) {
+    return Promise.resolve();
+  }
+
   const out = path.resolve(process.cwd(), config.browserify.out);
 
   return mkdir(out)

--- a/tasks/browserify/index.js
+++ b/tasks/browserify/index.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const browserify = require('browserify');
+const fs = require('fs');
+const path = require('path');
+
+const mkdir = require('../../lib/mkdir');
+
+module.exports = config => {
+  const out = path.resolve(process.cwd(), config.browserify.out);
+
+  return mkdir(out)
+    .then(() => {
+      return new Promise((resolve, reject) => {
+        const bundler = browserify(config.browserify.src);
+        const stream = bundler.bundle().pipe(fs.createWriteStream(out));
+        stream.on('finish', resolve).on('error', reject);
+      });
+    });
+
+};
+module.exports.task = 'browserify';

--- a/tasks/build/index.js
+++ b/tasks/build/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const tasks = require('../');
+const run = require('../../lib/run');
+
+module.exports = config => {
+  return run(Object.keys(tasks).map(task => tasks[task]), config);
+};

--- a/tasks/images/index.js
+++ b/tasks/images/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const spawn = require('../../lib/spawn');
+const mkdir = require('../../lib/mkdir');
+
+module.exports = config => {
+  return mkdir(config.images.out)
+    .then(() => {
+      return spawn('cp', ['-r', config.images.src, config.images.out]);
+    });
+};
+module.exports.task = 'copy images';

--- a/tasks/images/index.js
+++ b/tasks/images/index.js
@@ -4,9 +4,15 @@ const spawn = require('../../lib/spawn');
 const mkdir = require('../../lib/mkdir');
 
 module.exports = config => {
+
+  if (!config.images) {
+    return Promise.resolve();
+  }
+
   return mkdir(config.images.out)
     .then(() => {
       return spawn('cp', ['-r', config.images.src, config.images.out]);
     });
+
 };
 module.exports.task = 'copy images';

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  browserify: require('./browserify'),
+  sass: require('./sass'),
+  translate: require('./translate'),
+  images: require('./images')
+};

--- a/tasks/sass/index.js
+++ b/tasks/sass/index.js
@@ -8,6 +8,10 @@ const mkdir = require('../../lib/mkdir');
 
 module.exports = config => {
 
+  if (!config.sass) {
+    return Promise.resolve();
+  }
+
   const out = path.resolve(process.cwd(), config.sass.out);
 
   return mkdir(out)

--- a/tasks/sass/index.js
+++ b/tasks/sass/index.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const sass = require('npm-sass');
+
+const mkdir = require('../../lib/mkdir');
+
+module.exports = config => {
+
+  const out = path.resolve(process.cwd(), config.sass.out);
+
+  return mkdir(out)
+    .then(() => {
+      return new Promise((resolve, reject) => {
+        sass(config.sass.src, (err, result) => {
+          return err ? reject(err) : resolve(result.css);
+        });
+      });
+    })
+    .then(css => {
+      return new Promise((resolve, reject) => {
+        fs.writeFile(out, css, err => {
+          return err ? reject(err) : resolve();
+        });
+      });
+    });
+
+};
+module.exports.task = 'compile sass';

--- a/tasks/translate/index.js
+++ b/tasks/translate/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const spawn = require('../../lib/spawn');
+const witch = require('witch');
+
+module.exports = config => {
+
+  const args = [config.translate.src];
+  if (config.translate.shared) {
+    const shared = [].concat(config.translate.shared);
+    shared.forEach(path => {
+      args.push('--shared', path);
+    });
+  }
+
+  return spawn(witch('hof-transpiler'), args);
+
+};
+module.exports.task = 'compile translations';

--- a/tasks/translate/index.js
+++ b/tasks/translate/index.js
@@ -5,6 +5,10 @@ const witch = require('witch');
 
 module.exports = config => {
 
+  if (!config.translate) {
+    return Promise.resolve();
+  }
+
   const args = [config.translate.src];
   if (config.translate.shared) {
     const shared = [].concat(config.translate.shared);
@@ -14,6 +18,5 @@ module.exports = config => {
   }
 
   return spawn(witch('hof-transpiler'), args);
-
 };
 module.exports.task = 'compile translations';

--- a/tasks/watch/index.js
+++ b/tasks/watch/index.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const build = require('../build');
+const chokidar = require('chokidar');
+const throttle = require('lodash.throttle');
+const uniq = require('lodash.uniq');
+const cp = require('child_process');
+const match = require('minimatch');
+const chalk = require('chalk');
+const extname = require('path').extname;
+
+const tasks = require('../');
+
+const run = require('../../lib/run');
+
+module.exports = config => {
+
+  let toBuild = [];
+  let server;
+
+  const matchers = Object.keys(tasks).reduce((map, key) => {
+    if (!config[key]) {
+      return map;
+    }
+    const matcher = config[key].match || config[key].src;
+    if (matcher) {
+      map[key] = matcher;
+    }
+    return map;
+  }, {});
+
+  function triggersTask(path) {
+    return Object.keys(matchers).filter(key => {
+      return match(path, matchers[key]);
+    });
+  }
+
+  function restart() {
+    if (server) {
+      server.kill();
+      console.log(chalk.green('Restarting due to changes'));
+    }
+    const args = config.server.cmd.split(' ');
+    const cmd = args.shift();
+    server = cp.spawn(cmd, args, { stdio: 'inherit' });
+  }
+
+  function detectRestart(jobs, files) {
+    const restartingJobs = jobs.filter(job => config[job].restart !== false);
+    const restartingFiles = files.filter(file => config.server.extensions.indexOf(extname(file)) > -1);
+    return restartingJobs.length || restartingFiles.length;
+  }
+
+  function rebuild() {
+    let jobs = [];
+    toBuild.forEach(path => {
+      jobs = jobs.concat(triggersTask(path));
+    });
+    jobs = uniq(jobs);
+
+    jobs.forEach(job => {
+      console.log(`Executing build task: ${chalk.green(job)}`);
+    });
+
+    const shouldRestart = detectRestart(jobs, toBuild);
+    toBuild = [];
+    return run(jobs.map(task => tasks[task]), config)
+      .then(() => {
+        if (shouldRestart) {
+          restart();
+        }
+      });
+  }
+
+  function watch() {
+    return new Promise(resolve => {
+
+      const ignored = [].concat(config.watch.ignore);
+
+      if (!config.watchNodeModules) {
+        console.log('Ignoring node_modules directory. To watch node_modules run with --watch-node-modules flag');
+        ignored.push('node_modules');
+      }
+
+      const watcher = chokidar.watch('.', { ignored });
+
+      watcher.on('ready', () => {
+
+        const watched = watcher.getWatched();
+        console.log(`Watching ${Object.keys(watched).length} files for changes`);
+
+        const throttledRebuild = throttle(rebuild, 1000);
+        watcher.on('all', (event, file) => {
+          toBuild.push(file);
+          throttledRebuild();
+        });
+        resolve();
+      });
+
+    });
+  }
+
+  return build(config)
+    .then(() => {
+      return watch();
+    })
+    .then(() => {
+      return restart();
+    });
+
+};


### PR DESCRIPTION
Performs standard build tasks for a hof project based on default configuration in a single command.

Includes a `watch` command, which will perform a granular rebuild on file changes depending on what files have changed. This will also restart server processes on changes.

Making this granular makes it *way* faster than firearms existing nodemon solution.

A default build does the following things:

* browserify compile
* sass compile
* copy images
* compile translations

## Example

Based on firearms package.json, will turn this:

```
scripts: {
    "start": "node .",
    "dev": "npm-run-all --parallel watch:app watch:scss watch:js",
    "watch:app": "NODE_ENV=development nodemon -x 'npm run hof-transpile && npm start' --ignore 'apps/**/translations/en/'",
    "watch:scss": "nodemon -e scss -x 'npm run sass'",
    "watch:js": "nodemon --watch assets/js -e js -x 'npm run browserify'",
    "test": "NODE_ENV=test npm run lint && npm run test:unit",
    "test:unit": "istanbul cover _mocha",
    "test:acceptance": "funkie so-acceptance --steps",
    "lint": "npm-run-all --parallel lint:app lint:acceptance",
    "lint:app": "eslint .",
    "lint:acceptance": "eslint --no-ignore -c ./node_modules/so-acceptance/.eslintrc ./apps/*/features/**/*.js",
    "copy:images": "cp -r ./assets/images ./public/",
    "browserify": "browserify ./assets/js/index.js > ./public/js/bundle.js",
    "create:public": "mkdir -p ./public/js ./public/css ./public/images",
    "sass": "npm-sass ./assets/scss/app.scss > ./public/css/app.css",
    "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./apps/common/translations/src",
    "prepareapp": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile",
    "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run prepareapp; fi;'"
}
```

Into this:

```
scripts: {
    "start": "node .",
    "build": "hof-build",
    "dev": "hof-build watch",
    "test": "NODE_ENV=test npm run lint && npm run test:unit",
    "test:unit": "istanbul cover _mocha",
    "test:acceptance": "funkie so-acceptance --steps",
    "lint": "npm-run-all --parallel lint:app lint:acceptance",
    "lint:app": "eslint .",
    "lint:acceptance": "eslint --no-ignore -c ./node_modules/so-acceptance/.eslintrc ./apps/*/features/**/*.js",
    "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run build; fi;'"
}
```

As well as removing all associated dependencies.