### PR TITLE
Allow images directory to not exist

### DIFF
--- a/tasks/images/index.js
+++ b/tasks/images/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const chalk = require('chalk');
 const spawn = require('../../lib/spawn');
 const mkdir = require('../../lib/mkdir');
 
@@ -9,10 +11,24 @@ module.exports = config => {
     return Promise.resolve();
   }
 
-  return mkdir(config.images.out)
-    .then(() => {
-      return spawn('cp', ['-r', config.images.src, config.images.out]);
+  return new Promise((resolve, reject) => {
+    fs.stat(config.images.src, err => {
+      return err ? reject(err) : resolve();
     });
+  })
+  .then(() => {
+    return mkdir(config.images.out);
+  })
+  .then(() => {
+    return spawn('cp', ['-r', config.images.src, config.images.out]);
+  })
+  .catch(e => {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    } else {
+      console.log(`${chalk.yellow('warning')}: no images directory found at ${config.images.src}`);
+    }
+  });
 
 };
 module.exports.task = 'copy images';


### PR DESCRIPTION
A basic app likely won't have any images - instead of forcing a config override, just outputa warning and continue.