### PR TITLE
Auto-read config from hof.settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ You can additionally run a `watch` task to start a server instance, which will a
 
 ## Configuration
 
-The default settings will match those for an app generated using [`hof-generator`](https://npmjs.com/hof-generator). To override any of the configuration settings you can define a path to a local config file, which will be merged with [the default configuration](./config/defaults.js)
+The default settings will match those for an app generated using [`hof-generator`](https://npmjs.com/hof-generator).
+
+If a `hof.settings.json` file is found in the application root, then the `build` section of the settings file will be used to override [the default configuration](./config/defaults.js).
+
+Alternatively you can define a path to a local config file by passing a `--config` option
 
 ```
 hof-build --config /path/to/my/config.js

--- a/index.js
+++ b/index.js
@@ -10,6 +10,15 @@ module.exports = options => {
 
   merge(settings, config);
 
+  // load settings from ./hof.settings.json if it exists
+  try {
+    const localConfig = path.resolve(process.cwd(), './hof.settings.json');
+    const hofSettings = require(path.resolve(process.cwd(), './hof.settings.json')).build;
+    console.log(`Found local config at ${localConfig}`);
+    merge(settings, hofSettings);
+  } catch (e) {/* ignore */}
+
+  // load override config file if defined
   if (options.config) {
     merge(settings, require(path.resolve(process.cwd(), options.config)));
   }

--- a/index.js
+++ b/index.js
@@ -11,12 +11,18 @@ module.exports = options => {
   merge(settings, config);
 
   // load settings from ./hof.settings.json if it exists
+  let localConfig;
   try {
-    const localConfig = path.resolve(process.cwd(), './hof.settings.json');
-    const hofSettings = require(path.resolve(process.cwd(), './hof.settings.json')).build;
+    localConfig = path.resolve(process.cwd(), './hof.settings.json');
+  } catch (e) {
+    // ignore error for missing config file
+  }
+
+  if (localConfig) {
+    const hofSettings = require(localConfig).build;
     console.log(`Found local config at ${localConfig}`);
     merge(settings, hofSettings);
-  } catch (e) {/* ignore */}
+  }
 
   // load override config file if defined
   if (options.config) {


### PR DESCRIPTION
This file is part of an app generated with `hof-generator` and so should be used as the canonical config for build.