### PR TITLE
Compress js when building for production

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -5,7 +5,8 @@ module.exports = {
     src: 'assets/js/index.js',
     out: 'public/js/bundle.js',
     match: 'assets/js/**/*.js',
-    restart: false
+    restart: false,
+    compress: false
   },
   sass: {
     src: 'assets/scss/app.scss',

--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = options => {
   if (options.config) {
     merge(settings, require(path.resolve(process.cwd(), options.config)));
   }
+  if (options.production || process.env.NODE_ENV === 'production') {
+    settings.production = true;
+  }
 
   if (options['watch-node-modules']) {
     settings.watchNodeModules = true;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "npm-sass": "^2.0.0",
+    "uglify-js": "^2.8.22",
     "witch": "^1.0.0"
   },
   "devDependencies": {

--- a/tasks/browserify/compress.js
+++ b/tasks/browserify/compress.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const duplexify = require('duplexify');
+const spawn = require('child_process').spawn;
+const witch = require('witch');
+const bin = witch('uglify-js', 'uglifyjs');
+
+const args = ['--comments', '/copyright|licen(c|s)e/i', '--'];
+
+function uglify() {
+  const proc = spawn(bin, args, { stdio: 'pipe' });
+  return duplexify(proc.stdin, proc.stdout);
+}
+
+module.exports = uglify;

--- a/tasks/browserify/index.js
+++ b/tasks/browserify/index.js
@@ -3,6 +3,7 @@
 const browserify = require('browserify');
 const fs = require('fs');
 const path = require('path');
+const minify = require('./compress');
 
 const mkdir = require('../../lib/mkdir');
 
@@ -18,10 +19,16 @@ module.exports = config => {
     .then(() => {
       return new Promise((resolve, reject) => {
         const bundler = browserify(config.browserify.src);
-        const stream = bundler.bundle().pipe(fs.createWriteStream(out));
+
+        let stream = bundler.bundle();
+        if (config.browserify.compress || config.production) {
+          stream = stream.pipe(minify());
+        }
+        stream.pipe(fs.createWriteStream(out));
+
         stream.on('finish', resolve).on('error', reject);
       });
     });
-
 };
+
 module.exports.task = 'browserify';


### PR DESCRIPTION
Removes whitespace and comments from client-side js when browserifying it in a production environment. This is detected either from a `--production` flag on the build script, or on any parent npm script (which will set `NODE_ENV`).

Comments which contain copyright notices are preserved.