### PR TITLE
Fix crash when no local settings file

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,15 @@ module.exports = options => {
 
   // load settings from ./hof.settings.json if it exists
   let localConfig;
+  let hofSettings;
   try {
     localConfig = path.resolve(process.cwd(), './hof.settings.json');
+    hofSettings = require(localConfig).build;
   } catch (e) {
     // ignore error for missing config file
   }
 
-  if (localConfig) {
-    const hofSettings = require(localConfig).build;
+  if (hofSettings) {
     console.log(`Found local config at ${localConfig}`);
     merge(settings, hofSettings);
   }


### PR DESCRIPTION
The try/catch block only contained a `path.resolve` which will always succeed because it doesn't hit fs. Need to also include the require inside the try/catch to not crash when require-ing the file.