### PR TITLE
Add nodemon-like `rs` to restart functionality

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -29,6 +29,7 @@ module.exports = {
     extensions: ['.js', '.json', '.html']
   },
   watch: {
+    restart: 'rs',
     ignore: [
       '*.log',
       '.git',


### PR DESCRIPTION
Allows a user to restart the server when in `watch` mode without having to kill he process and re-run manually.