### PR TITLE
Build themes

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,9 @@ module.exports = options => {
     throw new Error(`Unknown task: ${task}`);
   }
 
-  return require(`./tasks/${task}`)(settings);
+  return require(`./tasks/${task}`)(settings)
+    .catch(e => {
+      throw e;
+    });
 
 };

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = options => {
   try {
     localConfig = path.resolve(process.cwd(), './hof.settings.json');
     hofSettings = require(localConfig).build;
+    hofSettings.theme = require(localConfig).theme;
   } catch (e) {
     // ignore error for missing config file
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "minimatch": "^3.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "npm-sass": "^2.0.0",
+    "npm-sass": "^2.1.0",
     "uglify-js": "^2.8.22",
     "witch": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/UKHomeOfficeForms/hof-build#readme",
   "dependencies": {
+    "aliasify": "^2.1.0",
     "browserify": "^14.1.0",
     "chalk": "^1.1.3",
     "chokidar": "^1.6.1",

--- a/tasks/browserify/index.js
+++ b/tasks/browserify/index.js
@@ -19,7 +19,13 @@ module.exports = config => {
     .then(() => {
       return new Promise((resolve, reject) => {
         const bundler = browserify(config.browserify.src);
-
+        if (config.theme) {
+          bundler.transform(require('aliasify'), {
+            aliases: {
+              '$$theme': `hof-theme-${config.theme}`
+            }
+          });
+        }
         let stream = bundler.bundle();
         if (config.browserify.compress || config.production) {
           stream = stream.pipe(minify());

--- a/tasks/sass/index.js
+++ b/tasks/sass/index.js
@@ -17,7 +17,11 @@ module.exports = config => {
   return mkdir(out)
     .then(() => {
       return new Promise((resolve, reject) => {
-        sass(config.sass.src, (err, result) => {
+        const aliases = {};
+        if (config.theme) {
+          aliases.$$theme = `hof-theme-${config.theme}`;
+        }
+        sass(config.sass.src, { aliases }, (err, result) => {
           return err ? reject(err) : resolve(result.css);
         });
       });

--- a/tasks/watch/index.js
+++ b/tasks/watch/index.js
@@ -68,6 +68,12 @@ module.exports = config => {
     });
     jobs = uniq(jobs);
 
+    if (toBuild.indexOf('hof.settings.json') > -1) {
+      console.log(chalk.red('Build configuration modified. Manual restart required.'));
+      server.kill();
+      process.exit();
+    }
+
     jobs.forEach(job => {
       console.log(`Executing build task: ${chalk.green(job)}`);
     });

--- a/tasks/watch/index.js
+++ b/tasks/watch/index.js
@@ -71,6 +71,7 @@ module.exports = config => {
     if (toBuild.indexOf('hof.settings.json') > -1) {
       console.log(chalk.red('Build configuration modified. Manual restart required.'));
       server.kill();
+      // eslint-disable-next-line no-process-exit
       process.exit();
     }
 


### PR DESCRIPTION
This allows a project to use `$$theme` placeholders in scss and js files which are then mapped to the relevant files from the configured themes when built.

This in turn allows for theme configuration to be reducible to a single point of configuration in `hof.settings.json`.

