### PR TITLE
Add environment variable loader to `watch` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ You can additionally run a `watch` task to start a server instance, which will a
 
 By default files inside `node_modules` directories and dotfiles will not trigger a restart. If you want to include these files then you can set `--watch-node-modules` and `--watch-dotfiles` flags respectively.
 
+### Local environment variables
+
+You can load local environment variables from a file by passing an `--env` flag to `hof-build watch` and creating a `.env` file in your project root that defines your local variables as follows:
+
+```
+MY_LOCAL_ENVVAR=foo
+MY_OTHER_ENVVAR=bar
+```
+
+_Note: `export` is not required, and values should not be quoted._
+
+To load variables from a file other than `.env` you should pass the location of the file as a value on the `--env` flag.
+
+```
+hof-build watch --env .envdev
+```
+
 ## Configuration
 
 The default settings will match those for an app generated using [`hof-generator`](https://npmjs.com/hof-generator).

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = options => {
   settings.watchNodeModules = options['watch-node-modules'];
   settings.watchDotFiles = options['watch-dotfiles'];
   settings.verbose = options.verbose;
+  settings.env = options.env;
 
   const task = options._[0] || 'build';
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function hasenv(envfile) {
+  return new Promise((resolve, reject) => {
+    fs.stat(envfile, (err, stat) => {
+      return err ? resolve(false) : resolve(stat.isFile());
+    });
+  });
+}
+
+function readenv(envfile) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(envfile, (err, data) => {
+      return err ? reject(err) : resolve(data);
+    });
+  });
+}
+
+function loadenv(envfile, enabled) {
+  return hasenv(envfile)
+    .then(exists => {
+      if (!exists && enabled) {
+        throw new Error(`No env file could be found at ${envfile}`);
+      } else if (exists && !enabled) {
+        console.log(`Local env file found at ${envfile}.`);
+        console.log('To load variables from this file run with --env.');
+      } else if (exists && enabled) {
+        console.log(`Loading variables from env file at ${envfile}`);
+        return readenv(envfile)
+          .then(env => {
+            return dotenv.parse(env);
+          });
+      }
+      return {};
+    });
+}
+
+module.exports = loadenv;

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const dotenv = require('dotenv');
 
 function hasenv(envfile) {
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     fs.stat(envfile, (err, stat) => {
       return err ? resolve(false) : resolve(stat.isFile());
     });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "chalk": "^1.1.3",
     "chokidar": "^1.6.1",
     "cp": "^0.2.0",
+    "dotenv": "^4.0.0",
     "duplexify": "^3.5.0",
     "hof-transpiler": "^2.0.2",
     "lodash.merge": "^4.6.0",

--- a/tasks/watch/index.js
+++ b/tasks/watch/index.js
@@ -5,6 +5,7 @@ const chokidar = require('chokidar');
 const throttle = require('lodash.throttle');
 const uniq = require('lodash.uniq');
 const cp = require('child_process');
+const path = require('path');
 const match = require('minimatch');
 const chalk = require('chalk');
 const extname = require('path').extname;
@@ -12,6 +13,7 @@ const extname = require('path').extname;
 const tasks = require('../');
 
 const run = require('../../lib/run');
+const env = require('../../lib/env');
 
 module.exports = config => {
 
@@ -134,9 +136,29 @@ module.exports = config => {
     });
   }
 
+  function loadenv() {
+    let envfile = '.env';
+    if (typeof config.env === 'string') {
+      envfile = config.env;
+    }
+    envfile = path.resolve(process.cwd(), envfile);
+    return env(envfile, !!config.env)
+      .then(dotenv => {
+        Object.keys(dotenv).forEach(key => {
+          if (process.env[key] && config.verbose) {
+            console.log(`  Overwriting environment variable ${key} with local value`);
+          }
+          process.env[key] = dotenv[key];
+        });
+      });
+  }
+
   return build(config)
     .then(() => {
       return watch();
+    })
+    .then(() => {
+      return loadenv();
     })
     .then(() => {
       return restart();

--- a/tasks/watch/index.js
+++ b/tasks/watch/index.js
@@ -31,9 +31,9 @@ module.exports = config => {
     return map;
   }, {});
 
-  function triggersTask(path) {
+  function triggersTask(file) {
     return Object.keys(matchers).filter(key => {
-      return match(path, matchers[key]);
+      return match(file, matchers[key]);
     });
   }
 
@@ -62,11 +62,11 @@ module.exports = config => {
 
   function rebuild() {
     let jobs = [];
-    toBuild.forEach(path => {
+    toBuild.forEach(file => {
       if (config.verbose) {
-        console.log(`${chalk.yellow('Changed')}: ${path}`);
+        console.log(`${chalk.yellow('Changed')}: ${file}`);
       }
-      jobs = jobs.concat(triggersTask(path));
+      jobs = jobs.concat(triggersTask(file));
     });
     jobs = uniq(jobs);
 


### PR DESCRIPTION
This allows local environment variables to be defined in a `.env` file in the project to be used for local development. This is easier to manage per-project than setting global env vars (which apply to all projects) or defining vars at runtime using the command line (which is cumbersome to repeat).

Additionally, allowing the file to be specified allows for the easy switching between multiple configuration setups.